### PR TITLE
fixed missing comma in example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,7 +27,7 @@ handler = TA_Handler(
     symbol="SYMBOL",
     exchange="EXCHANGE",
     screener="SCREENER",
-    interval="INTERVAL"
+    interval="INTERVAL",
     timeout=10 # 10 seconds timeout
 )
 ```


### PR DESCRIPTION
I was looking at your documentation noticed a missing comma for the TA_Handler example in it's parameters.